### PR TITLE
Hide backlinks in print media

### DIFF
--- a/css/journallink.css
+++ b/css/journallink.css
@@ -1,0 +1,5 @@
+@media print {
+  .journal-backlinks {
+    display: none;
+  }
+}

--- a/module.json
+++ b/module.json
@@ -15,7 +15,9 @@
   "esmodules": [
     "./scripts/index.js"
   ],
-  "styles": [],
+  "styles": [
+    "./css/journallink.css"
+  ],
   "languages": [
     {
       "lang": "en",


### PR DESCRIPTION
Add CSS styling to hide the backlinks section when a sheet is being printed.

Closes #6 