### PR TITLE
gracefully handle failures to find entities

### DIFF
--- a/scripts/journallink.js
+++ b/scripts/journallink.js
@@ -139,7 +139,12 @@ export class JournalLink {
         let linksList = $('<ul></ul>');
         for (const [type, values] of Object.entries(links)) {
             for (let value of values) {
-                let entity = game.documentIndex.uuids[value].leaves[0].entry;
+                let entity = game.documentIndex.uuids[value]?.leaves[0]?.entry;
+                if (!entity) {
+		    // this is a bug, but best to try to work around it and log
+                    this.log('ERROR | unable to find entity (try the sync button?)');
+		    continue;
+                }
                 if (!entity.testUserPermission(game.users.current, game.settings.get('journal-backlinks', 'minPermission')))
                     continue;
                 this.debug('adding link from ' + type + ' ' + entity.name);


### PR DESCRIPTION
This shouldn't be happening, and is a bug when it does, but we should try our best to not cause the whole module to fail in such circumstances, logging on these failures instead.

Progress on #14.